### PR TITLE
add links to regs in front-matter

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -35,6 +35,9 @@
 %%% DO NOT CHANGE ORDER 
 %%%
 %%% comment out each begin/end environment to remove the relevant section
+%%%
+%%% See https://www.bristol.ac.uk/academic-quality/pg/code-of-practice/assessment/content-format/#preliminary
+%%% for details
 
 \hypersetup{pageanchor=false}
 \maketitle
@@ -44,11 +47,13 @@
   \input{abstract}
 \end{abstract}
 
+%% This is optional
 \begin{dedication}
   To my darling mama,\\
   sine-qua-non.
 \end{dedication}
 
+%% This is optional
 \begin{acknowledgements}
 It is common practice (although totally optional) to acknowledge any third-party
 advice, contribution or influence you have found useful during your work.
@@ -57,6 +62,9 @@ and/or Advisor, external organisations or persons who  have supplied resources
 of some kind (e.g., funding, advice or time), and so on.
 \end{acknowledgements}
 
+%% This is mandatory
+%% See https://www.bristol.ac.uk/academic-quality/pg/published-and-collaborative-work/
+%% for examples
 \begin{statement}
 My dissertation does / does not {\color{red} (delete as appropriate)} include work that has been published, submitted or prepared for publication with me as an author.
 My dissertation does / does not {\color{red} (delete as appropriate)} include non-published collaborative work that contains data or contributions from others.


### PR DESCRIPTION
This is simply to clarify which chunks of front-matter are mandatory and which are not, while referring to regulations for clarity.